### PR TITLE
Add two exceptions for no-unused-vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,13 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-redeclare': 'error',
-    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        'argsIgnorePattern': '^_',
+        'ignoreRestSiblings': true,
+      },
+    ],
     '@typescript-eslint/no-use-before-define': 'error',
     'vue/padding-line-between-blocks': ['error', 'always'],
     'vue/html-self-closing': ['error', { html: { void: 'any' } }],
@@ -88,4 +94,4 @@ module.exports = {
   parserOptions: {
     parser: '@typescript-eslint/parser',
   },
-}
+};

--- a/index.js
+++ b/index.js
@@ -68,13 +68,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-redeclare': 'error',
-    '@typescript-eslint/no-unused-vars': [
-      'error',
-      {
-        'argsIgnorePattern': '^_',
-        'ignoreRestSiblings': true,
-      },
-    ],
+    '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
     '@typescript-eslint/no-use-before-define': 'error',
     'vue/padding-line-between-blocks': ['error', 'always'],
     'vue/html-self-closing': ['error', { html: { void: 'any' } }],


### PR DESCRIPTION
This adds two exceptions for the `no-unused-vars` rule when used with destructuring.

1. When only using a few outcomes from a larger result
```javascript
const [thing, _unused] = do_thing();
```

2. When removing an element from an object
```javascript
const {a, ...rest} = do_other_thing();
```